### PR TITLE
Updates for babel7 RC 1 breaking changes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,13 @@
 {
   "plugins": [
-    "@babel/plugin-proposal-class-properties"
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+    ["@babel/plugin-proposal-class-properties", { "loose": false }]
   ],
   "presets": [
-    "@babel/preset-stage-2"
   ],
   "ignore": [
     "config/",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,12 @@
     "react-spinkit": "^3.0.0"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0-beta.54",
-    "@babel/plugin-proposal-class-properties": "7.0.0-beta.54",
-    "@babel/preset-stage-2": "7.0.0-beta.54"
+    "@babel/core": "7.0.0-rc.1",
+    "@babel/plugin-proposal-class-properties": "7.0.0-rc.1",
+    "@babel/plugin-proposal-decorators": "7.0.0-rc.1",
+    "@babel/plugin-proposal-export-namespace-from": "7.0.0-rc.1",
+    "@babel/plugin-proposal-function-sent": "7.0.0-rc.1",
+    "@babel/plugin-proposal-numeric-separator": "7.0.0-rc.1",
+    "@babel/plugin-proposal-throw-expressions": "7.0.0-rc.1"
   }
 }


### PR DESCRIPTION
Babel 7 breaking changes remove preset stages, outlined in https://github.com/babel/babel/tree/master/packages/babel-preset-stage-0. This will be needed for Embark 3.2+.