### PR TITLE
Upgrade to Embark 3.2 (babel 7)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,9 @@
 {
   "plugins": [
-    "transform-object-rest-spread"
+    "@babel/plugin-proposal-class-properties"
   ],
   "presets": [
-    "stage-2"
+    "@babel/preset-stage-2"
   ],
   "ignore": [
     "config/",

--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,13 @@
 {
   "plugins": [
-    "@babel/plugin-proposal-class-properties"
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+    ["@babel/plugin-proposal-class-properties", { "loose": false }]
   ],
   "presets": [
-    "@babel/preset-stage-2"
   ],
   "ignore": [
     "config/",

--- a/app/js/utils.js
+++ b/app/js/utils.js
@@ -17,7 +17,7 @@
  * // returns '123-890'
  * @returns {String} the shortened string
  */
-function limitLength (strToShorten, maxLength, replacement, trimMiddle){
+export function limitLength (strToShorten, maxLength, replacement, trimMiddle){
     if(!strToShorten) return '';
 
     const fullStringLength = strToShorten.length;
@@ -50,7 +50,7 @@ function limitLength (strToShorten, maxLength, replacement, trimMiddle){
  * // returns '0x390-552'
  * @returns {String} the shortened string
  */
-function limitAddressLength (address, maxLength, replacement){
+export function limitAddressLength (address, maxLength, replacement){
   if(!address) return '';
   let prepend0x = false;
 
@@ -73,12 +73,6 @@ function limitAddressLength (address, maxLength, replacement){
  * // returns 123.1234
  * @returns {Number} the ethereum amount in fixed-point notation
  */
-function formatEth(eth, decimals){
+export function formatEth(eth, decimals){
   return Number.parseFloat(eth).toFixed(decimals);
 }
-  
-  module.exports = {
-    limitLength,
-    limitAddressLength,
-    formatEth
-  }

--- a/config/contracts.js
+++ b/config/contracts.js
@@ -52,5 +52,13 @@ module.exports = {
       protocol: 'https',
       type: "rpc"
     }
+  },
+
+  development: {
+    dappConnection: [
+      "ws://localhost:8546",
+      "http://localhost:8545",
+      "$WEB3"  // uses pre existing web3 object if available (e.g in Mist)
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,17 +4,499 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.54.tgz",
+      "integrity": "sha1-ACT5b99wKKIdaOJzr9TpUyFKHq0=",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.54"
+      }
+    },
+    "@babel/core": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.54.tgz",
+      "integrity": "sha1-JTxU0AlUA6XPp2Tn2bRYGUaS0Cs=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.54",
+        "@babel/generator": "7.0.0-beta.54",
+        "@babel/helpers": "7.0.0-beta.54",
+        "@babel/parser": "7.0.0-beta.54",
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54",
+        "convert-source-map": "1.5.1",
+        "debug": "3.1.0",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "resolve": "1.8.1",
+        "semver": "5.5.0",
+        "source-map": "0.5.7"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.54.tgz",
+      "integrity": "sha1-wEPH7r7r/X5mXZXCgaSq/IPU4ck=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.54",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.54.tgz",
+      "integrity": "sha1-FiYSaj+fxO0oCslCNyx9OWU9cSE=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.54"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.54.tgz",
+      "integrity": "sha1-MHh1UHoe2iSCoJqaTfaiVjL/s0s=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.54",
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.54.tgz",
+      "integrity": "sha1-dXvRibB3B0oAQCjP3l8IPDBsxsQ=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.54"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.54.tgz",
+      "integrity": "sha1-vOndxIQxexPSYVuv4rUk0NVtmd8=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.54"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.54.tgz",
+      "integrity": "sha1-SvjdT/kNvSmzvPhf/0OVLirhAW4=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.54"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.54.tgz",
+      "integrity": "sha1-YdKpoPmj4xg4pFjeu57r173SSbQ=",
       "dev": true
     },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+    "@babel/helper-regex": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.54.tgz",
+      "integrity": "sha1-isVi+FXxMvxo39ELEyVSVVrIcNk=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.54.tgz",
+      "integrity": "sha1-OaUAUqrddNQMc7fFjrljuQ+sVtM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.54",
+        "@babel/helper-wrap-function": "7.0.0-beta.54",
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.54.tgz",
+      "integrity": "sha1-kB9aFJOkEHmf06s+DA0p0YBxyJ8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "7.0.0-beta.54",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.54.tgz",
+      "integrity": "sha1-ic2IM8lUgaCCesahv8zduSt1oQk=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.54"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.54.tgz",
+      "integrity": "sha1-3Bt6SDowdKNTGzZSPgMVbZEKOio=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.54",
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.54.tgz",
+      "integrity": "sha1-uGqZqA79gWaMrvMHYQuWEZdEanQ=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.54.tgz",
+      "integrity": "sha1-FV1Qc1gym45waJcAF8P9dKmwhYQ=",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.54.tgz",
+      "integrity": "sha1-wBqmO1fJyNzodEeWyB2d8SHyDbQ=",
       "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.54.tgz",
+      "integrity": "sha1-GYcb1lW110iwrj6ezr4ke+i3+Ds=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.54",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.54.tgz",
+      "integrity": "sha1-WVPwSZweaecy0zpVC86HmaprdvM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.54",
+        "@babel/helper-member-expression-to-functions": "7.0.0-beta.54",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.54",
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/helper-replace-supers": "7.0.0-beta.54",
+        "@babel/plugin-syntax-class-properties": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-proposal-decorators": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.0.0-beta.54.tgz",
+      "integrity": "sha1-6xS9UiPO2MzsjmuQC6Al4E9JV40=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/plugin-syntax-decorators": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.0.0-beta.54.tgz",
+      "integrity": "sha1-h8zXNpSqDtsd23WNpAtkgDa0AxM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/plugin-syntax-export-namespace-from": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-proposal-function-sent": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-function-sent/-/plugin-proposal-function-sent-7.0.0-beta.54.tgz",
+      "integrity": "sha1-GMMyfOSX3BAUGQWBoroKpnu6ovE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/helper-wrap-function": "7.0.0-beta.54",
+        "@babel/plugin-syntax-function-sent": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0-beta.54.tgz",
+      "integrity": "sha1-NSkuBxazWsjCedZDCDbOdBwy/l0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/plugin-syntax-json-strings": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-proposal-numeric-separator": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.0.0-beta.54.tgz",
+      "integrity": "sha1-1zVmppxHXcexE/RYhF0rRF7fkpQ=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/plugin-syntax-numeric-separator": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.54.tgz",
+      "integrity": "sha1-VIEmmgIN0NOHFagJT+0BXTDvTCo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.54.tgz",
+      "integrity": "sha1-kx9pKY+gxBGyWWYWz1odgpJbh6k=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-proposal-throw-expressions": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-throw-expressions/-/plugin-proposal-throw-expressions-7.0.0-beta.54.tgz",
+      "integrity": "sha1-CgFdhgJvVSUbeQtRX5H1ZrUOFcA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/plugin-syntax-throw-expressions": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.54.tgz",
+      "integrity": "sha1-FiRjH69oi8veSRhxK9CvcYb30kU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/helper-regex": "7.0.0-beta.54",
+        "regexpu-core": "4.2.0"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.54.tgz",
+      "integrity": "sha1-/6yPZJJ2FHYol8yWQ0lf04CX3UE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.54.tgz",
+      "integrity": "sha1-XnDyLcNijB01QCtj/xqPjgBb2HE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-decorators": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.0.0-beta.54.tgz",
+      "integrity": "sha1-SzxX7LOzWpyZVEfgg71rUD7clbo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.54.tgz",
+      "integrity": "sha1-yWJif04aFdptCEIwbUIeex5S9Yc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.0.0-beta.54.tgz",
+      "integrity": "sha1-++RCYbRtOI4Q3vkyID6vBdEtzbc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-function-sent": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-function-sent/-/plugin-syntax-function-sent-7.0.0-beta.54.tgz",
+      "integrity": "sha1-dy2qi+90R5BXnjVo2Ym4YK85k9E=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.0.0-beta.54.tgz",
+      "integrity": "sha1-PFTQeq/glxQwO5laxK1rELD9vDA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0-beta.54.tgz",
+      "integrity": "sha1-f1PDU2LzWeWIHiEnjKM1ncC7cFU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.0.0-beta.54.tgz",
+      "integrity": "sha1-nk9W944NwozIG8zpXaTDO55YEV4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.54.tgz",
+      "integrity": "sha1-4PRFYSCBq1c+JTWturx7cQ0XlAw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.54.tgz",
+      "integrity": "sha1-Lrjd3hnd9zo0PQh6CHFZ7UTlSAk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/plugin-syntax-throw-expressions": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-throw-expressions/-/plugin-syntax-throw-expressions-7.0.0-beta.54.tgz",
+      "integrity": "sha1-0wWKsMY/5pCroVLC57CClOW3ep8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+      }
+    },
+    "@babel/preset-stage-2": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/preset-stage-2/-/preset-stage-2-7.0.0-beta.54.tgz",
+      "integrity": "sha1-v5Gw0TF+7vH/KIJsfwJS+8G91Po=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/plugin-proposal-decorators": "7.0.0-beta.54",
+        "@babel/plugin-proposal-export-namespace-from": "7.0.0-beta.54",
+        "@babel/plugin-proposal-function-sent": "7.0.0-beta.54",
+        "@babel/plugin-proposal-numeric-separator": "7.0.0-beta.54",
+        "@babel/plugin-proposal-throw-expressions": "7.0.0-beta.54",
+        "@babel/preset-stage-3": "7.0.0-beta.54"
+      }
+    },
+    "@babel/preset-stage-3": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/preset-stage-3/-/preset-stage-3-7.0.0-beta.54.tgz",
+      "integrity": "sha1-knW06pCAEaLa5U1ZFUo4BnNmjMY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.54",
+        "@babel/plugin-proposal-class-properties": "7.0.0-beta.54",
+        "@babel/plugin-proposal-json-strings": "7.0.0-beta.54",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.54",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.54",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.54",
+        "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.54",
+        "@babel/plugin-syntax-import-meta": "7.0.0-beta.54"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.54.tgz",
+      "integrity": "sha1-1bDS0tVcDniwSMYaBY82z9fZGvM=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.54",
+        "@babel/parser": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54",
+        "lodash": "4.17.10"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.54.tgz",
+      "integrity": "sha1-LBf5jc2/GaqRj94Sjw4aC8CJ4Fo=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.54",
+        "@babel/generator": "7.0.0-beta.54",
+        "@babel/helper-function-name": "7.0.0-beta.54",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.54",
+        "@babel/parser": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54",
+        "debug": "3.1.0",
+        "globals": "11.7.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.54.tgz",
+      "integrity": "sha1-AlrWhJL+1ULBPxTFeaRMhI5TEGM=",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "2.0.0"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.2"
+      }
     },
     "asap": {
       "version": "2.0.6",
@@ -26,249 +508,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "^4.17.10"
-      }
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      }
-    },
-    "babel-helper-bindify-decorators": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
-      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-explode-class": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-      "dev": true,
-      "requires": {
-        "babel-helper-bindify-decorators": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
-    },
-    "babel-plugin-syntax-async-generators": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
-      "dev": true
-    },
-    "babel-plugin-syntax-class-properties": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
-      "dev": true
-    },
-    "babel-plugin-syntax-decorators": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
-      "dev": true
-    },
-    "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
-      "dev": true
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-      "dev": true
-    },
-    "babel-plugin-transform-async-generator-functions": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-generators": "^6.5.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-class-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-decorators": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-class": "^6.24.1",
-        "babel-plugin-syntax-decorators": "^6.13.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
-      }
-    },
-    "babel-preset-stage-2": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-class-properties": "^6.24.1",
-        "babel-plugin-transform-decorators": "^6.24.1",
-        "babel-preset-stage-3": "^6.24.1"
-      }
-    },
-    "babel-preset-stage-3": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
-      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-generator-functions": "^6.24.1",
-        "babel-plugin-transform-async-to-generator": "^6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
-        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+        "lodash": "4.17.10"
       }
     },
     "babel-runtime": {
@@ -276,8 +516,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
@@ -287,71 +527,42 @@
         }
       }
     },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
-    },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       }
     },
     "classnames": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
     },
     "core-js": {
       "version": "1.2.7",
@@ -364,9 +575,9 @@
       "integrity": "sha1-WG6FUQfcRxe6TZ8sQc8Sw7clEsA="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -382,7 +593,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.23"
       }
     },
     "escape-string-regexp": {
@@ -398,57 +609,54 @@
       "dev": true
     },
     "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.18"
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
       "dev": true
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "history": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
       "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
       "requires": {
-        "invariant": "^2.2.1",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.2.0",
-        "value-equal": "^0.4.0",
-        "warning": "^3.0.0"
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
       }
     },
     "hoist-non-react-statics": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
-      "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "invariant": {
@@ -456,7 +664,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "is-stream": {
@@ -474,14 +682,26 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
       }
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
     },
     "keycode": {
       "version": "2.2.0",
@@ -499,11 +719,11 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "4.0.0"
       }
     },
     "ms": {
@@ -517,8 +737,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "npm": {
@@ -526,131 +746,131 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-6.2.0.tgz",
       "integrity": "sha512-GnlNsOnxwVJX4WSfyQY0gY3LnUX2cc46XU0eu1g+WSuZgDRUGmw8tuptitJu6byp0RWGT8ZEAKajblwdhQHN8A==",
       "requires": {
-        "JSONStream": "^1.3.3",
-        "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
-        "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
-        "bluebird": "~3.5.1",
-        "byte-size": "^4.0.3",
-        "cacache": "^11.0.2",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.5.0",
-        "cmd-shim": "~2.0.2",
-        "columnify": "~1.5.4",
-        "config-chain": "~1.1.11",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "figgy-pudding": "^3.1.0",
-        "find-npm-prefix": "^1.0.2",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
-        "glob": "~7.1.2",
-        "graceful-fs": "~4.1.11",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.6.0",
-        "iferr": "^1.0.0",
-        "imurmurhash": "*",
-        "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
-        "ini": "^1.3.5",
-        "init-package-json": "^1.10.3",
-        "is-cidr": "^2.0.6",
-        "json-parse-better-errors": "^1.0.2",
-        "lazy-property": "~1.0.0",
-        "libcipm": "^2.0.0",
-        "libnpmhook": "^4.0.1",
-        "libnpx": "^10.2.0",
-        "lock-verify": "^2.0.2",
-        "lockfile": "^1.0.4",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "^4.1.3",
-        "meant": "~1.0.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "~0.5.1",
-        "move-concurrently": "^1.0.1",
-        "node-gyp": "^3.7.0",
-        "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-audit-report": "^1.3.1",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^2.0.3",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "~1.1.10",
-        "npm-pick-manifest": "^2.1.0",
-        "npm-profile": "^3.0.2",
-        "npm-registry-client": "^8.5.1",
-        "npm-registry-fetch": "^1.1.0",
-        "npm-user-validate": "~1.0.0",
-        "npmlog": "~4.1.2",
-        "once": "~1.4.0",
-        "opener": "~1.4.3",
-        "osenv": "^0.1.5",
-        "pacote": "^8.1.6",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
-        "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.1.0",
-        "qw": "~1.0.1",
-        "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
-        "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
-        "readable-stream": "^2.3.6",
-        "readdir-scoped-modules": "*",
-        "request": "^2.81.0",
-        "retry": "^0.12.0",
-        "rimraf": "~2.6.2",
-        "safe-buffer": "^5.1.2",
-        "semver": "^5.5.0",
-        "sha": "~2.0.1",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.0",
-        "tar": "^4.4.4",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
+        "JSONStream": "1.3.3",
+        "abbrev": "1.1.1",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.2",
+        "bluebird": "3.5.1",
+        "byte-size": "4.0.3",
+        "cacache": "11.0.2",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cli-columns": "3.1.2",
+        "cli-table3": "0.5.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "figgy-pudding": "3.1.0",
+        "find-npm-prefix": "1.0.2",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.6.0",
+        "iferr": "1.0.0",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.3",
+        "is-cidr": "2.0.6",
+        "json-parse-better-errors": "1.0.2",
+        "lazy-property": "1.0.0",
+        "libcipm": "2.0.0",
+        "libnpmhook": "4.0.1",
+        "libnpx": "10.2.0",
+        "lock-verify": "2.0.2",
+        "lockfile": "1.0.4",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.3",
+        "meant": "1.0.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.7.0",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-audit-report": "1.3.1",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.0.3",
+        "npm-package-arg": "6.1.0",
+        "npm-packlist": "1.1.10",
+        "npm-pick-manifest": "2.1.0",
+        "npm-profile": "3.0.2",
+        "npm-registry-client": "8.5.1",
+        "npm-registry-fetch": "1.1.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.5",
+        "pacote": "8.1.6",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.12.0",
+        "query-string": "6.1.0",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.13",
+        "read-package-tree": "5.2.1",
+        "readable-stream": "2.3.6",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.81.0",
+        "retry": "0.12.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
+        "semver": "5.5.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "6.0.0",
+        "tar": "4.4.4",
+        "text-table": "0.2.0",
+        "tiny-relative-date": "1.3.0",
         "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
-        "unpipe": "~1.0.0",
-        "update-notifier": "^2.5.0",
-        "uuid": "^3.3.2",
-        "validate-npm-package-license": "^3.0.3",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "^1.3.1",
-        "worker-farm": "^1.6.0",
-        "wrappy": "~1.0.2",
-        "write-file-atomic": "^2.3.0"
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.5.0",
+        "uuid": "3.3.2",
+        "validate-npm-package-license": "3.0.3",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.1",
+        "worker-farm": "1.6.0",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "JSONStream": {
           "version": "1.3.3",
           "bundled": true,
           "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
           }
         },
         "abbrev": {
@@ -661,21 +881,21 @@
           "version": "4.2.0",
           "bundled": true,
           "requires": {
-            "es6-promisify": "^5.0.0"
+            "es6-promisify": "5.0.0"
           }
         },
         "agentkeepalive": {
           "version": "3.4.1",
           "bundled": true,
           "requires": {
-            "humanize-ms": "^1.2.1"
+            "humanize-ms": "1.2.1"
           }
         },
         "ansi-align": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.0.0"
+            "string-width": "2.1.1"
           }
         },
         "ansi-regex": {
@@ -686,7 +906,7 @@
           "version": "3.2.1",
           "bundled": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "ansicolors": {
@@ -709,8 +929,8 @@
           "version": "1.1.4",
           "bundled": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "asap": {
@@ -746,25 +966,25 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "bin-links": {
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
-            "write-file-atomic": "^2.3.0"
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "write-file-atomic": "2.3.0"
           }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "bluebird": {
@@ -775,27 +995,27 @@
           "version": "2.10.1",
           "bundled": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "boxen": {
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.4.1",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "2.0.0"
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -823,20 +1043,20 @@
           "version": "11.0.2",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "figgy-pudding": "^3.1.0",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.2",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^6.0.0",
-            "unique-filename": "^1.1.0",
-            "y18n": "^4.0.0"
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "figgy-pudding": "3.1.0",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "6.0.0",
+            "unique-filename": "1.1.0",
+            "y18n": "4.0.0"
           }
         },
         "call-limit": {
@@ -859,9 +1079,9 @@
           "version": "2.4.1",
           "bundled": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "chownr": {
@@ -876,7 +1096,7 @@
           "version": "2.0.9",
           "bundled": true,
           "requires": {
-            "ip-regex": "^2.1.0"
+            "ip-regex": "2.1.0"
           }
         },
         "cli-boxes": {
@@ -887,26 +1107,26 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.1"
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1"
           }
         },
         "cli-table3": {
           "version": "0.5.0",
           "bundled": true,
           "requires": {
-            "colors": "^1.1.2",
-            "object-assign": "^4.1.0",
-            "string-width": "^2.1.1"
+            "colors": "1.3.0",
+            "object-assign": "4.1.1",
+            "string-width": "2.1.1"
           }
         },
         "cliui": {
           "version": "4.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -917,7 +1137,7 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -930,8 +1150,8 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
           }
         },
         "co": {
@@ -946,7 +1166,7 @@
           "version": "1.9.1",
           "bundled": true,
           "requires": {
-            "color-name": "^1.1.1"
+            "color-name": "1.1.3"
           }
         },
         "color-name": {
@@ -962,15 +1182,15 @@
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "strip-ansi": "^3.0.0",
-            "wcwidth": "^1.0.0"
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
           }
         },
         "combined-stream": {
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
@@ -981,30 +1201,30 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
           }
         },
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
           }
         },
         "configstore": {
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.3.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
           }
         },
         "console-control-strings": {
@@ -1015,12 +1235,12 @@
           "version": "1.0.5",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "fs-write-stream-atomic": "^1.0.8",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.0"
+            "aproba": "1.2.0",
+            "fs-write-stream-atomic": "1.0.10",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           },
           "dependencies": {
             "iferr": {
@@ -1037,23 +1257,23 @@
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "capture-stack-trace": "^1.0.0"
+            "capture-stack-trace": "1.0.0"
           }
         },
         "cross-spawn": {
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "crypto-random-string": {
@@ -1068,7 +1288,7 @@
           "version": "1.14.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -1110,7 +1330,7 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "clone": "^1.0.2"
+            "clone": "1.0.4"
           }
         },
         "delayed-stream": {
@@ -1133,15 +1353,15 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "^2.0.0",
-            "wrappy": "1"
+            "asap": "2.0.6",
+            "wrappy": "1.0.2"
           }
         },
         "dot-prop": {
           "version": "4.2.0",
           "bundled": true,
           "requires": {
-            "is-obj": "^1.0.0"
+            "is-obj": "1.0.1"
           }
         },
         "dotenv": {
@@ -1156,10 +1376,10 @@
           "version": "3.6.0",
           "bundled": true,
           "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
+            "end-of-stream": "1.4.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
           }
         },
         "ecc-jsbn": {
@@ -1167,7 +1387,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "editor": {
@@ -1178,14 +1398,14 @@
           "version": "0.1.12",
           "bundled": true,
           "requires": {
-            "iconv-lite": "~0.4.13"
+            "iconv-lite": "0.4.23"
           }
         },
         "end-of-stream": {
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "err-code": {
@@ -1196,7 +1416,7 @@
           "version": "0.1.7",
           "bundled": true,
           "requires": {
-            "prr": "~1.0.1"
+            "prr": "1.0.1"
           }
         },
         "es6-promise": {
@@ -1207,7 +1427,7 @@
           "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "es6-promise": "^4.0.3"
+            "es6-promise": "4.2.4"
           }
         },
         "escape-string-regexp": {
@@ -1218,13 +1438,13 @@
           "version": "0.7.0",
           "bundled": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "extend": {
@@ -1247,15 +1467,15 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "flush-write-stream": {
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.4"
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "forever-agent": {
@@ -1266,43 +1486,43 @@
           "version": "2.1.4",
           "bundled": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "from2": {
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0"
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.6"
           },
           "dependencies": {
             "iferr": {
@@ -1319,33 +1539,33 @@
           "version": "1.0.11",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
           }
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -1358,14 +1578,14 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "fs-vacuum": "^1.2.10",
-            "graceful-fs": "^4.1.11",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "path-is-inside": "^1.0.2",
-            "read-cmd-shim": "^1.0.1",
-            "slide": "^1.1.6"
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
           },
           "dependencies": {
             "iferr": {
@@ -1386,7 +1606,7 @@
           "version": "0.1.7",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -1399,36 +1619,36 @@
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "global-dirs": {
           "version": "0.1.1",
           "bundled": true,
           "requires": {
-            "ini": "^1.3.4"
+            "ini": "1.3.5"
           }
         },
         "got": {
           "version": "6.7.1",
           "bundled": true,
           "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         },
         "graceful-fs": {
@@ -1443,16 +1663,16 @@
           "version": "4.2.1",
           "bundled": true,
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           },
           "dependencies": {
             "ajv": {
               "version": "4.11.8",
               "bundled": true,
               "requires": {
-                "co": "^4.6.0",
-                "json-stable-stringify": "^1.0.1"
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
               }
             }
           }
@@ -1469,10 +1689,10 @@
           "version": "3.1.3",
           "bundled": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -1491,7 +1711,7 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "agent-base": "4",
+            "agent-base": "4.2.0",
             "debug": "3.1.0"
           }
         },
@@ -1499,31 +1719,31 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
           }
         },
         "https-proxy-agent": {
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "agent-base": "^4.1.0",
-            "debug": "^3.1.0"
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
           }
         },
         "humanize-ms": {
           "version": "1.2.1",
           "bundled": true,
           "requires": {
-            "ms": "^2.0.0"
+            "ms": "2.1.1"
           }
         },
         "iconv-lite": {
           "version": "0.4.23",
           "bundled": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "iferr": {
@@ -1534,7 +1754,7 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "import-lazy": {
@@ -1549,8 +1769,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -1565,14 +1785,14 @@
           "version": "1.10.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-            "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
-            "validate-npm-package-name": "^3.0.0"
+            "glob": "7.1.2",
+            "npm-package-arg": "6.1.0",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.13",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "invert-kv": {
@@ -1591,36 +1811,36 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "builtin-modules": "^1.0.0"
+            "builtin-modules": "1.1.1"
           }
         },
         "is-ci": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "ci-info": "^1.0.0"
+            "ci-info": "1.1.3"
           }
         },
         "is-cidr": {
           "version": "2.0.6",
           "bundled": true,
           "requires": {
-            "cidr-regex": "^2.0.8"
+            "cidr-regex": "2.0.9"
           }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-installed-globally": {
           "version": "0.1.0",
           "bundled": true,
           "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
+            "global-dirs": "0.1.1",
+            "is-path-inside": "1.0.1"
           }
         },
         "is-npm": {
@@ -1635,7 +1855,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "path-is-inside": "^1.0.1"
+            "path-is-inside": "1.0.2"
           }
         },
         "is-redirect": {
@@ -1683,7 +1903,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -1718,7 +1938,7 @@
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "package-json": "^4.0.0"
+            "package-json": "4.0.1"
           }
         },
         "lazy-property": {
@@ -1729,45 +1949,45 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "1.0.0"
           }
         },
         "libcipm": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "bin-links": "^1.1.2",
-            "bluebird": "^3.5.1",
-            "find-npm-prefix": "^1.0.2",
-            "graceful-fs": "^4.1.11",
-            "lock-verify": "^2.0.2",
-            "npm-lifecycle": "^2.0.3",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.1.0",
-            "pacote": "^8.1.6",
-            "protoduck": "^5.0.0",
-            "read-package-json": "^2.0.13",
-            "rimraf": "^2.6.2",
-            "worker-farm": "^1.6.0"
+            "bin-links": "1.1.2",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.2",
+            "npm-lifecycle": "2.0.3",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.1.0",
+            "pacote": "8.1.6",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.13",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.6.0"
           }
         },
         "libnpmhook": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "^3.1.0",
-            "npm-registry-fetch": "^3.0.0"
+            "figgy-pudding": "3.1.0",
+            "npm-registry-fetch": "3.1.1"
           },
           "dependencies": {
             "npm-registry-fetch": {
               "version": "3.1.1",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.1.0",
-                "lru-cache": "^4.1.2",
-                "make-fetch-happen": "^4.0.0",
-                "npm-package-arg": "^6.0.0"
+                "bluebird": "3.5.1",
+                "figgy-pudding": "3.1.0",
+                "lru-cache": "4.1.3",
+                "make-fetch-happen": "4.0.1",
+                "npm-package-arg": "6.1.0"
               }
             }
           }
@@ -1776,37 +1996,37 @@
           "version": "10.2.0",
           "bundled": true,
           "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.1.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "update-notifier": "2.5.0",
+            "which": "1.3.1",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
           }
         },
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "lock-verify": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^5.1.2 || 6",
-            "semver": "^5.4.1"
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "signal-exit": "^3.0.2"
+            "signal-exit": "3.0.2"
           }
         },
         "lodash._baseindexof": {
@@ -1817,8 +2037,8 @@
           "version": "4.6.0",
           "bundled": true,
           "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
           }
         },
         "lodash._bindcallback": {
@@ -1833,7 +2053,7 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "lodash._getnative": "^3.0.0"
+            "lodash._getnative": "3.9.1"
           }
         },
         "lodash._createset": {
@@ -1876,32 +2096,32 @@
           "version": "4.1.3",
           "bundled": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "make-dir": {
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "make-fetch-happen": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "agentkeepalive": "^3.4.1",
-            "cacache": "^11.0.1",
-            "http-cache-semantics": "^3.8.1",
-            "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.1",
-            "lru-cache": "^4.1.2",
-            "mississippi": "^3.0.0",
-            "node-fetch-npm": "^2.0.2",
-            "promise-retry": "^1.1.1",
-            "socks-proxy-agent": "^4.0.0",
-            "ssri": "^6.0.0"
+            "agentkeepalive": "3.4.1",
+            "cacache": "11.0.2",
+            "http-cache-semantics": "3.8.1",
+            "http-proxy-agent": "2.1.0",
+            "https-proxy-agent": "2.2.1",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
+            "node-fetch-npm": "2.0.2",
+            "promise-retry": "1.1.1",
+            "socks-proxy-agent": "4.0.1",
+            "ssri": "6.0.0"
           }
         },
         "meant": {
@@ -1912,7 +2132,7 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "mime-db": {
@@ -1923,7 +2143,7 @@
           "version": "2.1.18",
           "bundled": true,
           "requires": {
-            "mime-db": "~1.33.0"
+            "mime-db": "1.33.0"
           }
         },
         "mimic-fn": {
@@ -1934,7 +2154,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -1945,8 +2165,8 @@
           "version": "2.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           },
           "dependencies": {
             "yallist": {
@@ -1959,23 +2179,23 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.3"
           }
         },
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "concat-stream": "1.6.2",
+            "duplexify": "3.6.0",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.3",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "3.0.0",
+            "pumpify": "1.5.1",
+            "stream-each": "1.2.2",
+            "through2": "2.0.3"
           }
         },
         "mkdirp": {
@@ -1989,12 +2209,12 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           }
         },
         "ms": {
@@ -2009,34 +2229,34 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "encoding": "^0.1.11",
-            "json-parse-better-errors": "^1.0.0",
-            "safe-buffer": "^5.1.1"
+            "encoding": "0.1.12",
+            "json-parse-better-errors": "1.0.2",
+            "safe-buffer": "5.1.2"
           }
         },
         "node-gyp": {
           "version": "3.7.0",
           "bundled": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": ">=2.9.0 <2.82.0",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.5",
+            "request": "2.81.0",
+            "rimraf": "2.6.2",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.1"
           },
           "dependencies": {
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
               }
             },
             "semver": {
@@ -2047,9 +2267,9 @@
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
               }
             }
           }
@@ -2058,26 +2278,26 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
           }
         },
         "npm-audit-report": {
           "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "cli-table3": "^0.5.0",
-            "console-control-strings": "^1.1.0"
+            "cli-table3": "0.5.0",
+            "console-control-strings": "1.1.0"
           }
         },
         "npm-bundled": {
@@ -2092,21 +2312,21 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
+            "semver": "5.5.0"
           }
         },
         "npm-lifecycle": {
           "version": "2.0.3",
           "bundled": true,
           "requires": {
-            "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.6.2",
-            "resolve-from": "^4.0.0",
-            "slide": "^1.1.6",
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.7.0",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
             "uid-number": "0.0.6",
-            "umask": "^1.1.0",
-            "which": "^1.3.0"
+            "umask": "1.1.0",
+            "which": "1.3.1"
           }
         },
         "npm-logical-tree": {
@@ -2117,52 +2337,52 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
-            "osenv": "^0.1.5",
-            "semver": "^5.5.0",
-            "validate-npm-package-name": "^3.0.0"
+            "hosted-git-info": "2.6.0",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npm-pick-manifest": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^6.0.0",
-            "semver": "^5.4.1"
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "npm-profile": {
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2 || 2",
-            "make-fetch-happen": "^2.5.0 || 3 || 4"
+            "aproba": "1.2.0",
+            "make-fetch-happen": "4.0.1"
           }
         },
         "npm-registry-client": {
           "version": "8.5.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^5.2.4"
+            "concat-stream": "1.6.2",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.81.0",
+            "retry": "0.10.1",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "ssri": "5.3.0"
           },
           "dependencies": {
             "retry": {
@@ -2173,7 +2393,7 @@
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -2182,47 +2402,47 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^2.0.1",
-            "lru-cache": "^4.1.2",
-            "make-fetch-happen": "^3.0.0",
-            "npm-package-arg": "^6.0.0",
-            "safe-buffer": "^5.1.1"
+            "bluebird": "3.5.1",
+            "figgy-pudding": "2.0.1",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "3.0.0",
+            "npm-package-arg": "6.1.0",
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "cacache": {
               "version": "10.0.4",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
+                "bluebird": "3.5.1",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.3",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.3.0",
+                "unique-filename": "1.1.0",
+                "y18n": "4.0.0"
               },
               "dependencies": {
                 "mississippi": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^2.0.1",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
+                    "concat-stream": "1.6.2",
+                    "duplexify": "3.6.0",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.3",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "2.0.1",
+                    "pumpify": "1.5.1",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
                   }
                 }
               }
@@ -2235,25 +2455,25 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^10.0.4",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.0",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.2.4"
+                "agentkeepalive": "3.4.1",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
               }
             },
             "pump": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
               }
             },
             "smart-buffer": {
@@ -2264,23 +2484,23 @@
               "version": "1.1.10",
               "bundled": true,
               "requires": {
-                "ip": "^1.1.4",
-                "smart-buffer": "^1.0.13"
+                "ip": "1.1.5",
+                "smart-buffer": "1.1.15"
               }
             },
             "socks-proxy-agent": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "agent-base": "^4.1.0",
-                "socks": "^1.1.10"
+                "agent-base": "4.2.0",
+                "socks": "1.1.10"
               }
             },
             "ssri": {
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -2289,7 +2509,7 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "path-key": "^2.0.0"
+            "path-key": "2.0.1"
           }
         },
         "npm-user-validate": {
@@ -2300,10 +2520,10 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -2322,7 +2542,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "opener": {
@@ -2337,9 +2557,9 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "os-tmpdir": {
@@ -2350,8 +2570,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "p-finally": {
@@ -2362,14 +2582,14 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.2.0"
           }
         },
         "p-try": {
@@ -2380,50 +2600,50 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.2",
+            "registry-url": "3.1.0",
+            "semver": "5.5.0"
           }
         },
         "pacote": {
           "version": "8.1.6",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^11.0.2",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.3",
-            "make-fetch-happen": "^4.0.1",
-            "minimatch": "^3.0.4",
-            "minipass": "^2.3.3",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
-            "osenv": "^0.1.5",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.2",
-            "semver": "^5.5.0",
-            "ssri": "^6.0.0",
-            "tar": "^4.4.3",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "bluebird": "3.5.1",
+            "cacache": "11.0.2",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "4.0.1",
+            "minimatch": "3.0.4",
+            "minipass": "2.3.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "ssri": "6.0.0",
+            "tar": "4.4.4",
+            "unique-filename": "1.1.0",
+            "which": "1.3.1"
           }
         },
         "parallel-transform": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "cyclist": "~0.2.2",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.1.5"
+            "cyclist": "0.2.2",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "path-exists": {
@@ -2466,8 +2686,8 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "err-code": "^1.0.0",
-            "retry": "^0.10.0"
+            "err-code": "1.1.2",
+            "retry": "0.10.1"
           },
           "dependencies": {
             "retry": {
@@ -2480,7 +2700,7 @@
           "version": "0.3.0",
           "bundled": true,
           "requires": {
-            "read": "1"
+            "read": "1.0.7"
           }
         },
         "proto-list": {
@@ -2491,7 +2711,7 @@
           "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "genfun": "^4.0.1"
+            "genfun": "4.0.1"
           }
         },
         "prr": {
@@ -2506,25 +2726,25 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "pumpify": {
           "version": "1.5.1",
           "bundled": true,
           "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
+            "duplexify": "3.6.0",
+            "inherits": "2.0.3",
+            "pump": "2.0.1"
           },
           "dependencies": {
             "pump": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
               }
             }
           }
@@ -2545,8 +2765,8 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "decode-uri-component": "^0.2.0",
-            "strict-uri-encode": "^2.0.0"
+            "decode-uri-component": "0.2.0",
+            "strict-uri-encode": "2.0.0"
           }
         },
         "qw": {
@@ -2557,10 +2777,10 @@
           "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2573,115 +2793,115 @@
           "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "~0.0.4"
+            "mute-stream": "0.0.7"
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2"
+            "graceful-fs": "4.1.11"
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
           }
         },
         "read-package-json": {
           "version": "2.0.13",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.1",
-            "normalize-package-data": "^2.0.0",
-            "slash": "^1.0.0"
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.2",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
           }
         },
         "read-package-tree": {
           "version": "5.2.1",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "graceful-fs": "^4.1.2",
-            "once": "^1.3.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
           }
         },
         "registry-auth-token": {
           "version": "3.3.2",
           "bundled": true,
           "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
+            "rc": "1.2.7",
+            "safe-buffer": "5.1.2"
           }
         },
         "registry-url": {
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "rc": "^1.0.1"
+            "rc": "1.2.7"
           }
         },
         "request": {
           "version": "2.81.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
         },
         "require-directory": {
@@ -2704,14 +2924,14 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "run-queue": {
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1"
+            "aproba": "1.2.0"
           }
         },
         "safe-buffer": {
@@ -2730,7 +2950,7 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "semver": "^5.0.3"
+            "semver": "5.5.0"
           }
         },
         "set-blocking": {
@@ -2741,15 +2961,15 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.6"
           }
         },
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "shebang-regex": "^1.0.0"
+            "shebang-regex": "1.0.0"
           }
         },
         "shebang-regex": {
@@ -2776,23 +2996,23 @@
           "version": "1.0.9",
           "bundled": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "socks": {
           "version": "2.2.0",
           "bundled": true,
           "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "^4.0.1"
+            "ip": "1.1.5",
+            "smart-buffer": "4.0.1"
           }
         },
         "socks-proxy-agent": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "agent-base": "~4.2.0",
-            "socks": "~2.2.0"
+            "agent-base": "4.2.0",
+            "socks": "2.2.0"
           }
         },
         "sorted-object": {
@@ -2803,16 +3023,16 @@
           "version": "2.1.3",
           "bundled": true,
           "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
           },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
               }
             },
             "isarray": {
@@ -2823,10 +3043,10 @@
               "version": "1.1.14",
               "bundled": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -2839,8 +3059,8 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -2851,8 +3071,8 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -2863,15 +3083,15 @@
           "version": "1.14.2",
           "bundled": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.2",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2",
+            "tweetnacl": "0.14.5"
           },
           "dependencies": {
             "assert-plus": {
@@ -2888,16 +3108,16 @@
           "version": "1.2.2",
           "bundled": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "stream-shift": "^1.0.0"
+            "end-of-stream": "1.4.1",
+            "stream-shift": "1.0.0"
           }
         },
         "stream-iterate": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "stream-shift": "^1.0.0"
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
           }
         },
         "stream-shift": {
@@ -2912,8 +3132,8 @@
           "version": "2.1.1",
           "bundled": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -2928,7 +3148,7 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -2937,7 +3157,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "stringstream": {
@@ -2948,7 +3168,7 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-eof": {
@@ -2963,20 +3183,20 @@
           "version": "5.4.0",
           "bundled": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "tar": {
           "version": "4.4.4",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.3",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           },
           "dependencies": {
             "yallist": {
@@ -2989,7 +3209,7 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "execa": "^0.7.0"
+            "execa": "0.7.0"
           }
         },
         "text-table": {
@@ -3004,8 +3224,8 @@
           "version": "2.0.3",
           "bundled": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         },
         "timed-out": {
@@ -3020,14 +3240,14 @@
           "version": "2.3.4",
           "bundled": true,
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.2"
           }
         },
         "tweetnacl": {
@@ -3051,21 +3271,21 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "unique-slug": "^2.0.0"
+            "unique-slug": "2.0.0"
           }
         },
         "unique-slug": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "imurmurhash": "^0.1.4"
+            "imurmurhash": "0.1.4"
           }
         },
         "unique-string": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "crypto-random-string": "^1.0.0"
+            "crypto-random-string": "1.0.0"
           }
         },
         "unpipe": {
@@ -3080,23 +3300,23 @@
           "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "boxen": "1.3.0",
+            "chalk": "2.4.1",
+            "configstore": "3.1.2",
+            "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
           }
         },
         "url-parse-lax": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "prepend-http": "^1.0.1"
+            "prepend-http": "1.0.4"
           }
         },
         "util-deprecate": {
@@ -3115,24 +3335,24 @@
           "version": "3.0.3",
           "bundled": true,
           "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "^1.0.3"
+            "builtins": "1.0.3"
           }
         },
         "verror": {
           "version": "1.10.0",
           "bundled": true,
           "requires": {
-            "assert-plus": "^1.0.0",
+            "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
+            "extsprintf": "1.3.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -3145,14 +3365,14 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "defaults": "^1.0.3"
+            "defaults": "1.0.3"
           }
         },
         "which": {
           "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         },
         "which-module": {
@@ -3163,16 +3383,16 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -3181,31 +3401,31 @@
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.1.1"
+            "string-width": "2.1.1"
           }
         },
         "worker-farm": {
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "~0.1.7"
+            "errno": "0.1.7"
           }
         },
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -3218,9 +3438,9 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
           }
         },
         "xdg-basedir": {
@@ -3243,18 +3463,18 @@
           "version": "11.0.0",
           "bundled": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           },
           "dependencies": {
             "y18n": {
@@ -3267,7 +3487,7 @@
           "version": "9.0.2",
           "bundled": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -3276,6 +3496,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "1.7.0",
@@ -3290,17 +3516,16 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "prop-types": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
       }
     },
     "prop-types-extra": {
@@ -3308,19 +3533,19 @@
       "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.0.tgz",
       "integrity": "sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==",
       "requires": {
-        "react-is": "^16.3.2",
-        "warning": "^3.0.0"
+        "react-is": "16.4.1",
+        "warning": "3.0.0"
       }
     },
     "react": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
-      "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "react-bootstrap": {
@@ -3328,47 +3553,52 @@
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.32.1.tgz",
       "integrity": "sha512-RbfzKUbsukWsToWqGHfCCyMFq9QQI0TznutdyxyJw6dih2NvIne25Mrssg8LZsprqtPpyQi8bN0L0Fx3fUsL8Q==",
       "requires": {
-        "babel-runtime": "^6.11.6",
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.0",
-        "invariant": "^2.2.1",
-        "keycode": "^2.1.2",
-        "prop-types": "^15.5.10",
-        "prop-types-extra": "^1.0.1",
-        "react-overlays": "^0.8.0",
-        "react-prop-types": "^0.4.0",
-        "react-transition-group": "^2.0.0",
-        "uncontrollable": "^4.1.0",
-        "warning": "^3.0.0"
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.6",
+        "dom-helpers": "3.3.1",
+        "invariant": "2.2.4",
+        "keycode": "2.2.0",
+        "prop-types": "15.6.2",
+        "prop-types-extra": "1.1.0",
+        "react-overlays": "0.8.3",
+        "react-prop-types": "0.4.0",
+        "react-transition-group": "2.4.0",
+        "uncontrollable": "4.1.0",
+        "warning": "3.0.0"
       }
     },
     "react-dom": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.0.tgz",
-      "integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "react-is": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.0.tgz",
-      "integrity": "sha512-8ADZg/mBw+t2Fbr5Hm1K64v8q8Q6E+DprV5wQ5A8PSLW6XP0XJFMdUskVEW8efQ5oUgWHn8EYdHEPAMF0Co6hA=="
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.1.tgz",
+      "integrity": "sha512-xpb0PpALlFWNw/q13A+1aHeyJyLYCg0/cCHPUA43zYluZuIPHaHL3k8OBsTgQtxqW0FhyDEMvi8fZ/+7+r4OSQ=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-overlays": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.8.3.tgz",
       "integrity": "sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==",
       "requires": {
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.1",
-        "prop-types": "^15.5.10",
-        "prop-types-extra": "^1.0.1",
-        "react-transition-group": "^2.2.0",
-        "warning": "^3.0.0"
+        "classnames": "2.2.6",
+        "dom-helpers": "3.3.1",
+        "prop-types": "15.6.2",
+        "prop-types-extra": "1.1.0",
+        "react-transition-group": "2.4.0",
+        "warning": "3.0.0"
       }
     },
     "react-prop-types": {
@@ -3376,34 +3606,54 @@
       "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
       "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
       "requires": {
-        "warning": "^3.0.0"
+        "warning": "3.0.0"
       }
     },
     "react-router": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
-      "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
       "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.3.0",
-        "invariant": "^2.2.2",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.5.4",
-        "warning": "^3.0.0"
+        "history": "4.7.2",
+        "hoist-non-react-statics": "2.5.5",
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.6.2",
+        "warning": "4.0.1"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
+          "integrity": "sha512-rAVtTNZw+cQPjvGp1ox0XC5Q2IBFyqoqh+QII4J/oguyu83Bax1apbo2eqB8bHRS+fqYUBagys6lqUoVwKSmXQ==",
+          "requires": {
+            "loose-envify": "1.4.0"
+          }
+        }
       }
     },
     "react-router-dom": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
-      "integrity": "sha512-cHMFC1ZoLDfEaMFoKTjN7fry/oczMgRt5BKfMAkTu5zEuJvUiPp1J8d0eXSVTnBh6pxlbdqDhozunOOLtmKfPA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
+      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
       "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.2",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.5.4",
-        "react-router": "^4.2.0",
-        "warning": "^3.0.0"
+        "history": "4.7.2",
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "prop-types": "15.6.2",
+        "react-router": "4.3.1",
+        "warning": "4.0.1"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
+          "integrity": "sha512-rAVtTNZw+cQPjvGp1ox0XC5Q2IBFyqoqh+QII4J/oguyu83Bax1apbo2eqB8bHRS+fqYUBagys6lqUoVwKSmXQ==",
+          "requires": {
+            "loose-envify": "1.4.0"
+          }
+        }
       }
     },
     "react-spinkit": {
@@ -3411,26 +3661,88 @@
       "resolved": "https://registry.npmjs.org/react-spinkit/-/react-spinkit-3.0.0.tgz",
       "integrity": "sha1-Mf2vThgXd2bFfRsfMzApD4SSqFo=",
       "requires": {
-        "classnames": "^2.2.3",
-        "loaders.css": "^0.1.2",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.8"
+        "classnames": "2.2.6",
+        "loaders.css": "0.1.2",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "react-transition-group": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
-      "integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
+      "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
       "requires": {
-        "dom-helpers": "^3.3.1",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1"
+        "dom-helpers": "3.3.1",
+        "loose-envify": "1.4.0",
+        "prop-types": "15.6.2",
+        "react-lifecycles-compat": "3.0.4"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+      "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.4.0"
       }
     },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "regexpu-core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+      "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.4.0",
+        "regenerate-unicode-properties": "7.0.0",
+        "regjsgen": "0.4.0",
+        "regjsparser": "0.3.0",
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.0.2"
+      }
+    },
+    "regjsgen": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+      "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+      "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-pathname": {
       "version": "2.2.0",
@@ -3442,30 +3754,42 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "ua-parser-js": {
@@ -3478,8 +3802,36 @@
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
       "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=",
       "requires": {
-        "invariant": "^2.1.0"
+        "invariant": "2.2.4"
       }
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+      "dev": true
     },
     "value-equal": {
       "version": "0.4.0",
@@ -3491,7 +3843,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "whatwg-fetch": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,12 @@
     "react-spinkit": "^3.0.0"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0-beta.54",
-    "@babel/plugin-proposal-class-properties": "7.0.0-beta.54",
-    "@babel/preset-stage-2": "7.0.0-beta.54"
+    "@babel/core": "7.0.0-rc.1",
+    "@babel/plugin-proposal-class-properties": "7.0.0-rc.1",
+    "@babel/plugin-proposal-decorators": "7.0.0-rc.1",
+    "@babel/plugin-proposal-export-namespace-from": "7.0.0-rc.1",
+    "@babel/plugin-proposal-function-sent": "7.0.0-rc.1",
+    "@babel/plugin-proposal-numeric-separator": "7.0.0-rc.1",
+    "@babel/plugin-proposal-throw-expressions": "7.0.0-rc.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-spinkit": "^3.0.0"
   },
   "devDependencies": {
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-stage-2": "^6.24.1"
+    "@babel/core": "7.0.0-beta.54",
+    "@babel/plugin-proposal-class-properties": "7.0.0-beta.54",
+    "@babel/preset-stage-2": "7.0.0-beta.54"
   }
 }


### PR DESCRIPTION
Updates required for upgrade to Embark 3.2 (in particular due to the Babel v7 dependency update).